### PR TITLE
Add script for running eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "eslint-config-airbnb-base": "^11.3.2",
     "eslint-plugin-import": "^2.14.0"
   },
-  "scripts": {},
+  "scripts": {
+    "lint": "eslint ./*.js"
+  },
   "author": "Aaron Crosman",
   "license": "GPL-3.0",
   "repository": "https://github.com/acrosman/fastdog"


### PR DESCRIPTION
I've added this line to scripts object inside `package.json,` did you mean something like that?

```
"scripts": {
    "lint": "eslint ./*.js"
  }
```